### PR TITLE
Enable full composition rendering to eliminate screen tearing

### DIFF
--- a/Linux/etc/X11/xorg.conf.d/20-nvidia.conf
+++ b/Linux/etc/X11/xorg.conf.d/20-nvidia.conf
@@ -1,0 +1,15 @@
+Section "Device"
+        Identifier "NVIDIA Card"
+        Driver     "nvidia"
+        VendorName "NVIDIA Corporation"
+        BoardName  "GeForce GTX 1050 Ti"
+EndSection
+
+Section "Screen"
+    Identifier     "Screen0"
+    Device         "Device0"
+    Monitor        "Monitor0"
+    Option         "ForceFullCompositionPipeline" "on"
+    Option         "AllowIndirectGLXProtocol" "off"
+    Option         "TripleBuffer" "on"
+EndSection


### PR DESCRIPTION
Screen tearing can in some cases be eliminated by tripple buffering the render and using full composition. This does not work in all cases, to check if it does, you can run

nvidia-settings --assign CurrentMetaMode="nvidia-auto-select +0+0 { ForceFullCompositionPipeline = On }"

Before installing this file. If you install this file, the setting will persist between boots of the x server